### PR TITLE
Fix local URLs to include trailing slashes

### DIFF
--- a/content/privacy-policy.md
+++ b/content/privacy-policy.md
@@ -1,6 +1,6 @@
 +++
 title = 'Our Privacy Policy'
-url = '/privacy-policy'
+url = '/privacy-policy/'
 description = "Information we collect. TL;DR: We don't."
 +++
 

--- a/content/terms.md
+++ b/content/terms.md
@@ -1,6 +1,6 @@
 +++
 title = "Terms of Use"
-url = "/terms"
+url = "/terms/"
 description = "Legal terms for using this site and the Zen application"
 +++
 

--- a/themes/zen/layouts/_default/baseof.html
+++ b/themes/zen/layouts/_default/baseof.html
@@ -78,9 +78,9 @@
           <div class="footer__section">
             <ul class="footer__nav-list">
               <li class="footer__nav-list-item"><strong>Legal</strong></li>
-              <li class="footer__nav-list-item"><a href="/privacy-policy" class="footer__nav-list-link">Privacy
+              <li class="footer__nav-list-item"><a href="/privacy-policy/" class="footer__nav-list-link">Privacy
                   Policy</a></li>
-              <li class="footer__nav-list-item"><a href="/terms" class="footer__nav-list-link">Terms of Use</a></li>
+              <li class="footer__nav-list-item"><a href="/terms/" class="footer__nav-list-link">Terms of Use</a></li>
               <li class="footer__nav-list-item">
                 <a href="{{ .Site.Params.codeOfConductLink }}" target="_blank"
                   rel="noopener noreferrer" class="footer__nav-list-link">Code of Conduct</a>


### PR DESCRIPTION
This, in addition to a custom CF URL rewrite rule, allows access to `zenprivacy.net/privacy-policy/index.html` from `zenprivacy.net/privacy-policy/`