### PR TITLE
Add button styling to inherit font properties

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -16,6 +16,10 @@ html, body {
   padding: 0;
 }
 
+button {
+  font: inherit;
+}
+
 h1 {
   font-size: 2rem;
 }


### PR DESCRIPTION
This fixes button font styling on Windows.