### PR TITLE
Remove target attribute from Enterprise link

### DIFF
--- a/themes/zen/layouts/_default/baseof.html
+++ b/themes/zen/layouts/_default/baseof.html
@@ -72,7 +72,7 @@
     
           <div class="heading__mode-switch">
             <a href="/" class="heading__mode-link heading__mode-link--active">Personal</a>
-            <a href="https://zen.irbis.sh/enterprise" class="heading__mode-link" target="_blank">Enterprise</a>
+            <a href="https://zen.irbis.sh/enterprise" class="heading__mode-link">Enterprise</a>
           </div>
         </div>
     


### PR DESCRIPTION
This reflects the link behavior on the enterprise site.